### PR TITLE
toolbox: Use subprocess.check_call not call

### DIFF
--- a/enrichm/toolbox.py
+++ b/enrichm/toolbox.py
@@ -69,7 +69,7 @@ def run_command(cmd):
     :rtype: bool
     '''
     logging.debug(cmd)
-    subprocess.call(cmd, shell=True)
+    subprocess.check_call(cmd, shell=True)
     logging.debug('Finished')
 
 def get_present_annotations(input_dictionary):


### PR DESCRIPTION
Hi Joel,

I've not tested this but I reckon this is probably worth doing in case some command fails for a reason that has nothing to do with EnrichM, for instance.