### PR TITLE
Bug fix and new features

### DIFF
--- a/bin/enrichm
+++ b/bin/enrichm
@@ -157,12 +157,18 @@ if __name__ == "__main__":
                 help='Annotate with EC ids')
 
     annotate_cutoff_options = annotate.add_argument_group('Cutoff options')
-    annotate_cutoff_options.add_argument('--cut_ga', action='store_true',
-                help='For PFAM and TIGRfam searches: use profiles GA gathering cutoffs to set all thresholding')
-    annotate_cutoff_options.add_argument('--cut_nc', action='store_true',
-                help='For PFAM and TIGRfam searches: use profiles NC noise cutoffs to set all thresholding')
-    annotate_cutoff_options.add_argument('--cut_tc', action='store_true',
-                help='For PFAM and TIGRfam searches: use profiles TC trusted cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_ga_pfam', action='store_true',
+                help='For PFAM searches: use profiles GA gathering cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_nc_pfam', action='store_true',
+                help='For PFAM searches: use profiles NC noise cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_tc_pfam', action='store_true',
+                help='For PFAM searches: use profiles TC trusted cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_ga_tigrfam', action='store_true',
+                help='For TIGRfam searches: use profiles GA gathering cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_nc_tigrfam', action='store_true',
+                help='For TIGRfam searches: use profiles NC noise cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_tc_tigrfam', action='store_true',
+                help='For TIGRfam searches: use profiles TC trusted cutoffs to set all thresholding')
     annotate_cutoff_options.add_argument('--cut_ko', action='store_true',
                 help='For KO HMM annotation searches: use cutoffs defined by KEGG to maximise F-score.')
     annotate_cutoff_options.add_argument('--evalue', type=float, default=1e-05,

--- a/build/lib/enrichm/annotate.py
+++ b/build/lib/enrichm/annotate.py
@@ -359,12 +359,18 @@ class Annotate:
 
         self.hmm_search(output_directory_path, database, hmmcutoff)
 
+        if ids_type == AnnotationParser.PFAM:
+            pfam2clan = self.databases.pfam2clan()
+        else:
+            pfam2clan = None
+
         for genome_annotation in listdir(output_directory_path):
             genome_id = path.splitext(genome_annotation)[0]
             genome = genome_dict[genome_id]
             output_annotation_path = path.join(output_directory_path, genome_annotation)
             genome.add(output_annotation_path, self.evalue, self.bit, self.aln_query,
-                       self.aln_reference, specific_cutoffs, parser, ids_type)
+                       self.aln_reference, specific_cutoffs, parser, ids_type,
+                       pfam2clan=pfam2clan)
 
     def annotate_hypothetical(self, genomes_list):
         '''

--- a/build/lib/enrichm/annotate.py
+++ b/build/lib/enrichm/annotate.py
@@ -76,8 +76,8 @@ class Annotate:
 
     def __init__(self, output_directory, annotate_ko, annotate_ko_hmm, annotate_pfam, annotate_tigrfam,
                  annoatate_cluster, annotate_ortholog, annotate_cazy, annotate_ec, evalue, bit, percent_id_cutoff,
-                 aln_query, aln_reference, fraction_aligned, cut_ga, cut_nc, cut_tc,
-                 cut_hmm, inflation, chunk_number, chunk_max, count_domains,
+                 aln_query, aln_reference, fraction_aligned, cut_ga_pfam, cut_nc_pfam, cut_tc_pfam,
+                 cut_ga_tigrfam, cut_nc_tigrfam, cut_tc_tigrfam, cut_hmm, inflation, chunk_number, chunk_max, count_domains,
                  threads, parallel, suffix, light):
 
         # Define inputs and outputs
@@ -100,9 +100,12 @@ class Annotate:
         self.aln_query = aln_query
         self.aln_reference = aln_reference
         self.fraction_aligned = fraction_aligned
-        self.cut_ga = cut_ga
-        self.cut_nc = cut_nc
-        self.cut_tc = cut_tc
+        self.cut_ga_pfam = cut_ga_pfam
+        self.cut_nc_pfam = cut_nc_pfam
+        self.cut_tc_pfam = cut_tc_pfam
+        self.cut_ga_tigrfam = cut_ga_tigrfam
+        self.cut_nc_tigrfam = cut_nc_tigrfam
+        self.cut_tc_tigrfam = cut_tc_tigrfam
         self.cut_hmm = cut_hmm
         self.inflation = inflation
         self.chunk_number = chunk_number
@@ -598,13 +601,19 @@ class Annotate:
                           % (input_genome_path, self.PROTEINS_SUFFIX, self.parallel,
                              self.threads, output_path, self.ANNOTATION_SUFFIX)
         if hmmcutoff:
-            if(self.cut_ga or self.cut_nc or self.cut_tc):
-
-                if self.cut_ga:
+            if (self.cut_ga_pfam or self.cut_nc_pfam or self.cut_tc_pfam) and 'pfam' in database:
+                if self.cut_ga_pfam:
                     cmd += " --cut_ga "
-                if self.cut_nc:
+                if self.cut_nc_pfam:
                     cmd += " --cut_nc "
-                if self.cut_tc:
+                if self.cut_tc_pfam:
+                    cmd += " --cut_tc "
+            elif (self.cut_ga_tigrfam or self.cut_nc_tigrfam or self.cut_tc_tigrfam) and 'tigrfam' in database:
+                if self.cut_ga_tigrfam:
+                    cmd += " --cut_ga "
+                if self.cut_nc_tigrfam:
+                    cmd += " --cut_nc "
+                if self.cut_tc_tigrfam:
                     cmd += " --cut_tc "
             else:
                 cmd += self._default_hmmsearch_options()

--- a/build/lib/enrichm/classifier.py
+++ b/build/lib/enrichm/classifier.py
@@ -92,10 +92,10 @@ class Classify:
 
         logging.info("Read in annotations for %i genomes" % len(genome_to_annotation_sets))
 
-        output_lines = ['\t'.join(["Genome_name", "Module_id", "Module_name", "Steps_found",
-                             "Steps_needed", "Percent_steps_found"]) + '\n'] # "KO_found", "KO_needed", "Percent_KO_found"
+        output_lines = [["Genome_name", "Module_id", "Module_name", "Steps_found",
+                             "Steps_needed", "Percent_steps_found"]] # "KO_found", "KO_needed", "Percent_KO_found"
 
-        genome_output_lines = ['\t'.join(["Genome_name", "Module_id", "Module_name"]) + '\n']
+        genome_output_lines = [["Genome_name", "Module_id", "Module_name"]]
 
         for name, pathway_string in self.m2def.items():
 
@@ -146,7 +146,7 @@ class Classify:
 
         if aggregate:
             samples = list(abundance_result.keys() )
-            output_lines = ['\t'.join(["ID"] + samples) + '\n']
+            output_lines = [["ID"] + samples]
 
             for module in self.m2def.keys():
 

--- a/build/lib/enrichm/genome.py
+++ b/build/lib/enrichm/genome.py
@@ -349,7 +349,11 @@ class Sequence(Genome):
                     for overlapping_previous_annotation in overlap:
 
                         if annotation_type==AnnotationParser.PFAM:
-                            if pfam2clan[new_annotation.annotation] == pfam2clan[overlapping_previous_annotation.annotation]:
+                            if (new_annotation.annotation.split('.')[0] in pfam2clan
+                            and overlapping_previous_annotation.annotation.split('.')[0] in pfam2clan
+                            and pfam2clan[new_annotation.annotation.split('.')[0]]
+                                == pfam2clan[overlapping_previous_annotation.annotation.split('.')[0]]
+                            ):
                                 if new_annotation.compare(overlapping_previous_annotation):
                                     to_remove.append(overlapping_previous_annotation)
                             else:

--- a/build/lib/enrichm/parser.py
+++ b/build/lib/enrichm/parser.py
@@ -41,7 +41,10 @@ class Parser:
         for line in open(genome_and_annotation_file):
 
             try:
-                genome, annotation = line.strip().split("\t")
+                if line == '\n':
+                    continue
+                else:
+                    genome, annotation = line.strip().split("\t")
 
             except:
                 raise Exception("Input genomes/annotation file error on %s" % line)

--- a/build/lib/enrichm/run.py
+++ b/build/lib/enrichm/run.py
@@ -159,12 +159,17 @@ class Run:
         if(args.aln_reference>1 or args.aln_reference<0):
             raise Exception("Alignment to reference cutoff (--aln_reference) must be between 0 and 1")
 
-        if any([args.cut_ga, args.cut_nc, args.cut_tc]):
-            if len([x for x in [args.cut_ga, args.cut_nc, args.cut_tc] if x])>1:
-                raise Exception("Only one of the following can be selected: --cut_ga, --cut_nc, --cut_tc")
-
+        if any([args.cut_ga_pfam, args.cut_nc_pfam, args.cut_tc_pfam]):
+            if len([x for x in [args.cut_ga_pfam, args.cut_nc_pfam, args.cut_tc_pfam] if x])>1:
+                raise Exception("Only one of the following can be selected: --cut_ga_pfam, --cut_nc_pfam, --cut_tc_pfam")
             if args.evalue:
-                logging.warning('selecting one of the following overrides evalue thresholds: --cut_ga, --cut_nc, --cut_tc')
+                logging.warning('selecting one of the following overrides evalue thresholds: --cut_ga_pfam, --cut_nc_pfam, --cut_tc_pfam, --cut_ga_tigrfam, --cut_nc_tigrfam, --cut_tc_tigrfam')
+
+        if any([args.cut_ga_tigrfam, args.cut_nc_tigrfam, args.cut_tc_tigrfam]):
+            if len([x for x in [args.cut_ga_tigrfam, args.cut_nc_tigrfam, args.cut_tc_tigrfam] if x])>1:
+                raise Exception("Only one of the following can be selected: --cut_ga_tigrfam, --cut_nc_tigrfam, --cut_tc_tigrfam")
+            if args.evalue:
+                logging.warning('selecting one of the following overrides evalue thresholds: --cut_ga_pfam, --cut_nc_pfam, --cut_tc_pfam, --cut_ga_tigrfam, --cut_nc_tigrfam, --cut_tc_tigrfam')
 
     def _check_enrichment(self, args):
         '''
@@ -347,12 +352,15 @@ class Run:
                                 args.ec,
                                 # Cutoffs
                                 args.evalue, args.bit, args.id, args.aln_query,
-                                args.aln_reference, args.c, args.cut_ga, 
-                                args.cut_nc, args.cut_tc, args.cut_ko,
-                                args.inflation, args.chunk_number, args.chunk_max,
+                                args.aln_reference, args.c, args.cut_ga_pfam,
+                                args.cut_nc_pfam, args.cut_tc_pfam,
+                                args.cut_ga_tigrfam, args.cut_nc_tigrfam,
+                                args.cut_tc_tigrfam, args.cut_ko, args.inflation,
+                                args.chunk_number, args.chunk_max,
                                 args.count_domains,
                                 # Parameters
                                 args.threads, args.parallel, args.suffix, args.light)
+
             annotate.annotate_pipeline(args.genome_directory,
                                        args.protein_directory,
                                        args.genome_files,

--- a/build/scripts-3.5/enrichm
+++ b/build/scripts-3.5/enrichm
@@ -137,7 +137,7 @@ if __name__ == "__main__":
 
     annotate_annotation_options = annotate.add_argument_group('Annotations options')
     annotate_annotation_options.add_argument('--ko', action='store_true',
-                help='Annotate with KO ids')   
+                help='Annotate with KO ids')
     annotate_annotation_options.add_argument('--pfam', action='store_true',
                 help='Annotate with Pfam HMMs')
     annotate_annotation_options.add_argument('--tigrfam', action='store_true',
@@ -146,14 +146,20 @@ if __name__ == "__main__":
                 help='Annotate with hypothetical clusters')
     annotate_annotation_options.add_argument('--cazy', action='store_true',
                 help='Annotate with dbCAN HMMs')
-    
+
     annotate_cutoff_options = annotate.add_argument_group('Cutoff options')
-    annotate_cutoff_options.add_argument('--cut_ga', action='store_true',
-                help='For PFAM and TIGRfam searches: use profiles GA gathering cutoffs to set all thresholding')
-    annotate_cutoff_options.add_argument('--cut_nc', action='store_true',
-                help='For PFAM and TIGRfam searches: use profiles NC noise cutoffs to set all thresholding')
-    annotate_cutoff_options.add_argument('--cut_tc', action='store_true',
-                help='For PFAM and TIGRfam searches: use profiles TC trusted cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_ga_pfam', action='store_true',
+                help='For PFAM searches: use profiles GA gathering cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_nc_pfam', action='store_true',
+                help='For PFAM searches: use profiles NC noise cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_tc_pfam', action='store_true',
+                help='For PFAM searches: use profiles TC trusted cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_ga_tigrfam', action='store_true',
+                help='For TIGRfam searches: use profiles GA gathering cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_nc_tigrfam', action='store_true',
+                help='For TIGRfam searches: use profiles NC noise cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_tc_tigrfam', action='store_true',
+                help='For TIGRfam searches: use profiles TC trusted cutoffs to set all thresholding')
     annotate_cutoff_options.add_argument('--evalue', type=float, default=1e-05,
                 help='Use this evalue cutoff to filter false positives (default: 1e-05)')
     annotate_cutoff_options.add_argument('--bit', type = float, default = 0,

--- a/build/scripts-3.7/enrichm
+++ b/build/scripts-3.7/enrichm
@@ -150,12 +150,18 @@ if __name__ == "__main__":
                 help='Annotate with EC ids')
 
     annotate_cutoff_options = annotate.add_argument_group('Cutoff options')
-    annotate_cutoff_options.add_argument('--cut_ga', action='store_true',
-                help='For PFAM and TIGRfam searches: use profiles GA gathering cutoffs to set all thresholding')
-    annotate_cutoff_options.add_argument('--cut_nc', action='store_true',
-                help='For PFAM and TIGRfam searches: use profiles NC noise cutoffs to set all thresholding')
-    annotate_cutoff_options.add_argument('--cut_tc', action='store_true',
-                help='For PFAM and TIGRfam searches: use profiles TC trusted cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_ga_pfam', action='store_true',
+                help='For PFAM searches: use profiles GA gathering cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_nc_pfam', action='store_true',
+                help='For PFAM searches: use profiles NC noise cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_tc_pfam', action='store_true',
+                help='For PFAM searches: use profiles TC trusted cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_ga_tigrfam', action='store_true',
+                help='For TIGRfam searches: use profiles GA gathering cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_nc_tigrfam', action='store_true',
+                help='For TIGRfam searches: use profiles NC noise cutoffs to set all thresholding')
+    annotate_cutoff_options.add_argument('--cut_tc_tigrfam', action='store_true',
+                help='For TIGRfam searches: use profiles TC trusted cutoffs to set all thresholding')
     annotate_cutoff_options.add_argument('--evalue', type=float, default=1e-05,
                 help='Use this evalue cutoff to filter false positives (default: 1e-05)')
     annotate_cutoff_options.add_argument('--bit', type = float, default = 0,

--- a/enrichm/annotate.py
+++ b/enrichm/annotate.py
@@ -77,8 +77,9 @@ class Annotate:
 
     def __init__(self, output_directory, annotate_ko, annotate_ko_hmm, annotate_pfam,
                  annotate_tigrfam, annoatate_cluster, annotate_ortholog, annotate_cazy, annotate_ec,
-                 evalue, bit, percent_id_cutoff, aln_query, aln_reference, fraction_aligned, cut_ga,
-                 cut_nc, cut_tc, cut_hmm, inflation, chunk_number, chunk_max, count_domains,
+                 evalue, bit, percent_id_cutoff, aln_query, aln_reference, fraction_aligned,
+                 cut_ga_pfam, cut_nc_pfam, cut_tc_pfam, cut_ga_tigrfam, cut_nc_tigrfam,
+                 cut_tc_tigrfam, cut_hmm, inflation, chunk_number, chunk_max, count_domains,
                  threads, parallel, suffix, light):
 
         # Define inputs and outputs
@@ -101,9 +102,12 @@ class Annotate:
         self.aln_query = aln_query
         self.aln_reference = aln_reference
         self.fraction_aligned = fraction_aligned
-        self.cut_ga = cut_ga
-        self.cut_nc = cut_nc
-        self.cut_tc = cut_tc
+        self.cut_ga_pfam = cut_ga_pfam
+        self.cut_nc_pfam = cut_nc_pfam
+        self.cut_tc_pfam = cut_tc_pfam
+        self.cut_ga_tigrfam = cut_ga_tigrfam
+        self.cut_nc_tigrfam = cut_nc_tigrfam
+        self.cut_tc_tigrfam = cut_tc_tigrfam
         self.cut_hmm = cut_hmm
         self.inflation = inflation
         self.chunk_number = chunk_number
@@ -575,13 +579,19 @@ class Annotate:
                           % (input_genome_path, self.PROTEINS_SUFFIX, self.parallel,
                              self.threads, output_path, self.ANNOTATION_SUFFIX)
         if hmmcutoff:
-            if(self.cut_ga or self.cut_nc or self.cut_tc):
-
-                if self.cut_ga:
+            if (self.cut_ga_pfam or self.cut_nc_pfam or self.cut_tc_pfam) and 'pfam' in database:
+                if self.cut_ga_pfam:
                     cmd += " --cut_ga "
-                if self.cut_nc:
+                if self.cut_nc_pfam:
                     cmd += " --cut_nc "
-                if self.cut_tc:
+                if self.cut_tc_pfam:
+                    cmd += " --cut_tc "
+            elif (self.cut_ga_tigrfam or self.cut_nc_tigrfam or self.cut_tc_tigrfam) and 'tigrfam' in database:
+                if self.cut_ga_tigrfam:
+                    cmd += " --cut_ga "
+                if self.cut_nc_tigrfam:
+                    cmd += " --cut_nc "
+                if self.cut_tc_tigrfam:
                     cmd += " --cut_tc "
             else:
                 cmd += self._default_hmmsearch_options()

--- a/enrichm/annotate.py
+++ b/enrichm/annotate.py
@@ -355,12 +355,18 @@ class Annotate:
 
         self.hmm_search(output_directory_path, database, hmmcutoff)
 
+        if ids_type == AnnotationParser.PFAM:
+            pfam2clan = self.databases.pfam2clan()
+        else:
+            pfam2clan = None
+
         for genome_annotation in listdir(output_directory_path):
             genome_id = path.splitext(genome_annotation)[0]
             genome = genome_dict[genome_id]
             output_annotation_path = path.join(output_directory_path, genome_annotation)
             genome.add(output_annotation_path, self.evalue, self.bit, self.aln_query,
-                       self.aln_reference, specific_cutoffs, parser, ids_type)
+                       self.aln_reference, specific_cutoffs, parser, ids_type,
+                       pfam2clan=pfam2clan)
 
     def annotate_hypothetical(self, genomes_list):
         '''
@@ -669,10 +675,10 @@ class Annotate:
         output_directory_path = path.join(self.output_directory,
                                           self.GENOME_OBJ)
         mkdir(output_directory_path)
-        
+
         for genome in genomes_list:
             genome_pickle_path = path.join(output_directory_path, genome.name + self.PICKLE_SUFFIX)
-            
+
             with open(genome_pickle_path, 'wb') as output:
                 pickle.dump(genome, output)
 

--- a/enrichm/data.py
+++ b/enrichm/data.py
@@ -17,7 +17,7 @@
 ###############################################################################
 # Imports
 import os
-import urllib
+import urllib.request
 import shutil
 import logging
 from pathlib import Path

--- a/enrichm/genome.py
+++ b/enrichm/genome.py
@@ -349,7 +349,11 @@ class Sequence(Genome):
                     for overlapping_previous_annotation in overlap:
 
                         if annotation_type==AnnotationParser.PFAM:
-                            if pfam2clan[new_annotation.annotation] == pfam2clan[overlapping_previous_annotation.annotation]:
+                            if (new_annotation.annotation.split('.')[0] in pfam2clan
+                            and overlapping_previous_annotation.annotation.split('.')[0] in pfam2clan
+                            and pfam2clan[new_annotation.annotation.split('.')[0]]
+                                == pfam2clan[overlapping_previous_annotation.annotation.split('.')[0]]
+                            ):
                                 if new_annotation.compare(overlapping_previous_annotation):
                                     to_remove.append(overlapping_previous_annotation)
                             else:

--- a/enrichm/run.py
+++ b/enrichm/run.py
@@ -144,12 +144,17 @@ class Run:
         if(args.aln_reference>1 or args.aln_reference<0):
             raise Exception("Alignment to reference cutoff (--aln_reference) must be between 0 and 1")
 
-        if any([args.cut_ga, args.cut_nc, args.cut_tc]):
-            if len([x for x in [args.cut_ga, args.cut_nc, args.cut_tc] if x])>1:
-                raise Exception("Only one of the following can be selected: --cut_ga, --cut_nc, --cut_tc")
-
+        if any([args.cut_ga_pfam, args.cut_nc_pfam, args.cut_tc_pfam]):
+            if len([x for x in [args.cut_ga_pfam, args.cut_nc_pfam, args.cut_tc_pfam] if x])>1:
+                raise Exception("Only one of the following can be selected: --cut_ga_pfam, --cut_nc_pfam, --cut_tc_pfam")
             if args.evalue:
-                logging.warning('selecting one of the following overrides evalue thresholds: --cut_ga, --cut_nc, --cut_tc')
+                logging.warning('selecting one of the following overrides evalue thresholds: --cut_ga_pfam, --cut_nc_pfam, --cut_tc_pfam, --cut_ga_tigrfam, --cut_nc_tigrfam, --cut_tc_tigrfam')
+
+        if any([args.cut_ga_tigrfam, args.cut_nc_tigrfam, args.cut_tc_tigrfam]):
+            if len([x for x in [args.cut_ga_tigrfam, args.cut_nc_tigrfam, args.cut_tc_tigrfam] if x])>1:
+                raise Exception("Only one of the following can be selected: --cut_ga_tigrfam, --cut_nc_tigrfam, --cut_tc_tigrfam")
+            if args.evalue:
+                logging.warning('selecting one of the following overrides evalue thresholds: --cut_ga_pfam, --cut_nc_pfam, --cut_tc_pfam, --cut_ga_tigrfam, --cut_nc_tigrfam, --cut_tc_tigrfam')
 
     def _check_enrichment(self, args):
         '''
@@ -292,9 +297,11 @@ class Run:
                                 args.ec,
                                 # Cutoffs
                                 args.evalue, args.bit, args.id, args.aln_query,
-                                args.aln_reference, args.c, args.cut_ga, 
-                                args.cut_nc, args.cut_tc, args.cut_ko,
-                                args.inflation, args.chunk_number, args.chunk_max,
+                                args.aln_reference, args.c, args.cut_ga_pfam,
+                                args.cut_nc_pfam, args.cut_tc_pfam,
+                                args.cut_ga_tigrfam, args.cut_nc_tigrfam,
+                                args.cut_tc_tigrfam, args.cut_ko, args.inflation,
+                                args.chunk_number, args.chunk_max,
                                 args.count_domains,
                                 # Parameters
                                 args.threads, args.parallel, args.suffix, args.light)


### PR DESCRIPTION
I know that opening a PR with multiple unrelated fixes and new functions isn't ideal, but I've been working with this slightly modified version of enrichM and I decided to share my fixes and additions.

This PR does the following:
- Fixes https://github.com/geronimp/enrichM/issues/105
- Fixes https://github.com/geronimp/enrichM/issues/104
- Fixes https://github.com/geronimp/enrichM/issues/103
- Splits Pfam and TIGRFAM HMM cutoffs into separate arguments. This way the user can use, for instance, `--cut_ga` for Pfam and `--cut_nc` for TIGRFAM.
- If two Pfam domains overlap the one with the highest E-value is discarded if both belong to the same clan. This behaviour is the same of ` pfam_scan.pl`.