### PR TITLE
feat(BPA-627): prints None when there are not hits

### DIFF
--- a/enrichm/classifier.py
+++ b/enrichm/classifier.py
@@ -148,7 +148,10 @@ class Classify:
                                     pathway_average_abundance = 0
                                 abundance_result[genome][name] = pathway_average_abundance
 
-                            genome_output_lines.append([genome, name, self.modules[name], ','.join(ko_path_list)])
+                            if len(ko_path_list) > 0:
+                                genome_output_lines.append([genome, name, self.modules[name], ','.join(ko_path_list)])
+                            else:
+                                genome_output_lines.append([genome, name, self.modules[name], None])
                             output_line = [genome, name, self.modules[name], str(num_covered), str(num_all), str(round(perc_covered * 100, 2))]
                             output_lines.append(output_line)
 


### PR DESCRIPTION
When there are no modules found in the genome it prints out None. 

This way the `module_paths.tsv` file would persistently have 4 tab-seperated columns. Before this change, when there were no hits found, it does not print anything making the `module_paths.tsv` file of 3 tab-seperated columns. 

Before:
-------
```
$ less negative_enrichm_results/module_paths.tsv
Genome_name     Module_id       Module_name
<a-genome-name>      <a-module-id>     Custom 
```

After:
------
``` 
$ less negative_enrichm_results/module_paths.tsv
Genome_name     Module_id       Module_name
<a-genome-name>      <a-module-id>     Custom     None
```