### PR TITLE
feat(BPA-628): added a boolean for checking ENRICMDB

### DIFF
--- a/enrichm/classifier.py
+++ b/enrichm/classifier.py
@@ -21,11 +21,15 @@ class Classify:
     Determines which metabolic pathways are encoded by different MAGs
     '''
 
-    def __init__(self):
-        databases = Databases()
-        self.signature_modules = databases.signature_modules
-        self.m2def = databases.m2def()
-        self.modules = databases.m()
+    def __init__(self, skip_database_check=False):
+        self.signature_modules = set()
+        self.m2def = dict()
+        self.modules = dict()
+        if not skip_database_check:
+            databases = Databases()
+            self.signature_modules = databases.signature_modules
+            self.m2def = databases.m2def()
+            self.modules = databases.m()
         self.ko_output = "module_completeness.tsv"
         self.module_paths = "module_paths.tsv"
         self.aggregate_output = "aggregate_output.tsv"

--- a/enrichm/run.py
+++ b/enrichm/run.py
@@ -308,7 +308,10 @@ class Run:
 
     def run_classify(self, args):
         self._check_classify(args)
-        classify = Classify()
+        skip_database_check  = False
+        if args.custom_modules:
+            skip_database_check = True
+        classify = Classify(skip_database_check)
         classify.classify_pipeline(args.custom_modules, args.cutoff, args.aggregate,
                                     args.genome_and_annotation_matrix, args.module_rules_json, 
                                     args.gff_files, args.output)


### PR DESCRIPTION
Changes in this pull request only affect the classify pipeline with the following new (non-disruptive) behavior:

if `--custom_modules` is passed as an argument, the pipeline won't check for external database via `ENRICHM_DB` environment variable and it check for the external DB otherwise. 

Tested. 